### PR TITLE
Separa doctests de tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Construye imagen
       run: docker build --tag islasgeci .
-    - name: Ejecuta objetivo principal del Makefile
-      run: docker run islasgeci tests
-    - name: Ejecuta objetivo principal del Makefile
-      run: docker run islasgeci doctests
+    - name: Corre pruebas
+      run: docker run islasgeci make tests
+    - name: Corre doctests
+      run: docker run islasgeci make doctests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Copia repositorio
       uses: actions/checkout@v2
     - name: Construye imagen
-      run: docker build --tag islasgeci/queries .
+      run: docker build --tag islasgeci .
     - name: Ejecuta objetivo principal del Makefile
       run: docker run islasgeci tests
     - name: Ejecuta objetivo principal del Makefile

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,8 +1,8 @@
-name: Ciencia de Datos - GECI
+name: Conservación de Islas
 on: [push, pull_request]
 
 jobs:
-  actions:
+  tests_in_container:
     runs-on: ubuntu-18.04
     steps:
     - name: Copia repositorio
@@ -10,4 +10,6 @@ jobs:
     - name: Construye imagen
       run: docker build --tag islasgeci/queries .
     - name: Ejecuta objetivo principal del Makefile
-      run: docker run islasgeci/queries
+      run: docker run islasgeci tests
+    - name: Ejecuta objetivo principal del Makefile
+      run: docker run islasgeci doctests

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,16 @@
-tests: doctests test_cambia_formato_fecha test_dependencies
+tests: test_cambia_formato_fecha
 
 SHELL := /bin/bash
 
 # Enlista phonies
-.PHONY: doctests install test_cambia_formato_fecha test_dependencies tests
-
-test_dependencies:
-	pip freeze | grep shelldoctest
+.PHONY: doctests install test_cambia_formato_fecha tests
 
 test_cambia_formato_fecha: install
 	[ $$(tail -1 tests/data/test.csv | cut --characters=1-11) == "01/Dic/2019" ] && \
     [ $$(cambia_formato_fecha tests/data/test.csv | tail -1 | cut --characters=1-10) == "2019-12-01" ]
 
 doctests: install
+	pip freeze | grep shelldoctest
 	shell-doctest test tests/test_cambia_formato_fecha.py | grep "failures" && exit 1 || exit 0
 	cambia_formato_fecha --help | grep "$$ cambia_formato_fecha"
 


### PR DESCRIPTION
Separa doctests de tests ya que shelldoctests no corre con Python 3 y por lo tanto no puedo correr las pruebas en nuestras imágenes Base y Jupyter

[Instala descarga_datos en imágenes Base y Jupyter](https://app.gitkraken.com/glo/card/1ba211aa47864903ab85308e1c70c463)