### PR TITLE
Feature/geci 42/cambia query de repositorio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     jq \
     make \
     python-pip
+RUN apt-get install --yes git
 RUN pip install setuptools
 RUN pip install shelldoctest
+RUN git clone https://github.com/bats-core/bats-core.git && \
+    cd bats-core && \
+    ./install.sh /usr/local
 CMD make

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 tests: test_cambia_formato_fecha
+	bats tests/bats_tests/test_select_growth_rates_and_p_values.sh
 
 SHELL := /bin/bash
 

--- a/src/query_select_growth_rates_and_p_values.sql
+++ b/src/query_select_growth_rates_and_p_values.sql
@@ -1,0 +1,10 @@
+SELECT 
+  Islet AS 'Archipelago/Island',
+  Growth_rate AS 'Growth rate',
+  CASE
+    WHEN ${p_value_column} < 0.001
+    THEN '$<0.001$'
+    ELSE ${p_value_column}
+  END 'p-value'
+FROM ${table_name}
+WHERE ${p_value_column} ${conditional}

--- a/src/select_growth_rates_and_p_values
+++ b/src/select_growth_rates_and_p_values
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Este query selecciona la tasa de crecimiento poblacional y el p-valor de las tablas de tasas de
+# crecimiento por isla.
+
+data_file=${1}
+export table_name=$(basename "${data_file}" .csv)
+export p_value_column=${2}
+export conditional=${3}
+src_path=$(dirname "${0}")
+query=$(envsubst < ${src_path}/query_select_growth_rates_and_p_values.sql)
+
+csvsql --snifflimit 0 --no-inference --blanks --query "${query}" ${data_file}

--- a/tests/bats_tests/test_select_growth_rates_and_p_values.sh
+++ b/tests/bats_tests/test_select_growth_rates_and_p_values.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "select_growth_rates_and_p_values" {
+  run cat tests/data/output_test_select_growth_rates_and_p_vales.csv
+  result="$(./src/select_growth_rates_and_p_values tests/data/cormorant_all_islets_growth_rates.csv p_value "<= 0.1")"
+  [ "$output" = "$result" ]
+}

--- a/tests/data/cormorant_all_islets_growth_rates.csv
+++ b/tests/data/cormorant_all_islets_growth_rates.csv
@@ -1,0 +1,4 @@
+Islet,Growth_rate,p_value,p_value_menor
+Alcatraz,${0.98}_{-0.01}^{+0.01}$,1.0,0.0
+Asuncion,${1.23}_{-0.19}^{+0.25}$,0.0,1.0
+Coronado,${1.09}_{-0.17}^{+0.09}$,0.4,0.6

--- a/tests/data/output_test_select_growth_rates_and_p_vales.csv
+++ b/tests/data/output_test_select_growth_rates_and_p_vales.csv
@@ -1,0 +1,2 @@
+Archipelago/Island,Growth rate,p-value
+Asuncion,${1.23}_{-0.19}^{+0.25}$,$<0.001$


### PR DESCRIPTION
Hola equipo. Moví el query `select_growth_rates_and_p_values` que utilizamos en el repo de [lambdas](https://bitbucket.org/IslasGECI/lambdas_aves_marinas/src/develop/src/query_regional_growth_rates_and_p_values) y en el de [cormoran_population_growth](https://bitbucket.org/IslasGECI/cormorant_population_growth/src/develop/src/select_growth_rates_and_p_values), para que no esté repetido en ambos repos. Ya tiene su prueba en bats.

**Checklist de implementación en bash:**

- [x] Existe Doctest (ahora Bats), pruebas unitarias o prueba de integración.