### PR TITLE
🐞 Corrige bug en make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ doctests: install
 
 # Instala este repo copiando los ejecutables a ~/bin
 install:
+	chmod +x ./src/*
 	mkdir --parents /usr/local/bin
-	cp ./src/* /usr/local/bin
-	chmod +x /usr/local/bin/*
+	cp --preserve ./src/* /usr/local/bin
 	export PATH="/usr/local/bin:$${PATH}"
 	# Doctest:
 	mkdir --parents /usr/local/doctests


### PR DESCRIPTION
Estoy tratando de resolver el siguiente error:

```
make install
```
```
chmod +x /usr/local/bin/*
chmod: cannot operate on dangling symlink '/usr/local/bin/pandoc-citeproc'
make: *** [Makefile:28: install] Error 1
```
Para replicar el error intenta construir una imagen a partir de [este Dockerfile](https://github.com/IslasGECI/docker/blob/develop/Dockerfile.base) sin usar cache.
Tambien puedes ver el error [aquí](https://github.com/IslasGECI/docker/runs/2082637593).