### PR TITLE
Agrega script para correr queries en sqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,6 @@ install:
 	pip install . --upgrade
 
 bats_tests:
-	bats tests/bats_tests/test_run_query.sh \
-	tests/bats_tests/test_select_growth_rates_and_p_values.sh
+	bats \
+		tests/bats_tests/test_run_query.sh \
+		tests/bats_tests/test_select_growth_rates_and_p_values.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-tests: install test_select_growth_rates_and_p_values
+tests: install bats_tests
 	shellspec tests/shellspec_tests/
 
 SHELL := /bin/bash
@@ -38,5 +38,6 @@ install:
 	export PATH="/usr/local/bin:$${PATH}"
 	pip install . --upgrade
 
-test_select_growth_rates_and_p_values:
-	bats tests/bats_tests/test_select_growth_rates_and_p_values.sh
+bats_tests:
+	bats tests/bats_tests/test_run_query.sh \
+	tests/bats_tests/test_select_growth_rates_and_p_values.sh \

--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ install:
 
 bats_tests:
 	bats tests/bats_tests/test_run_query.sh \
-	tests/bats_tests/test_select_growth_rates_and_p_values.sh \
+	tests/bats_tests/test_select_growth_rates_and_p_values.sh

--- a/src/run_query
+++ b/src/run_query
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Función que corre en sqlite los queries de los archivos sql
+
+sql_query=${1}
+data_file=${2}
+export table_name=$(basename "${data_file}" .csv)
+query_name=$(basename "${sql_query}" .sql)
+path=$(dirname ${sql_query})
+query=$(envsubst < ${path}/${query_name}.sql)
+
+csvsql --snifflimit 0 --no-inference --blanks --query "${query}" \
+  ${data_file}

--- a/src/run_query
+++ b/src/run_query
@@ -2,11 +2,11 @@
 #
 # Función que corre en sqlite los queries de los archivos sql
 
-sql_query=${1}
+query_file=${1}
 data_file=${2}
 export table_name=$(basename "${data_file}" .csv)
-query_name=$(basename "${sql_query}" .sql)
-path=$(dirname ${sql_query})
+query_name=$(basename "${query_file}" .sql)
+path=$(dirname ${query_file})
 query=$(envsubst < ${path}/${query_name}.sql)
 
 csvsql --snifflimit 0 --no-inference --blanks --query "${query}" \

--- a/tests/bats_tests/test_run_query.sh
+++ b/tests/bats_tests/test_run_query.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+@test "run_query" {
+  run ./src/run_query tests/data/query_prueba.sql tests/data/test_2019-2020.csv
+  [ "$output" = "Temporada,Fecha,Cantidad_de_trampas_activas,Cantidad_de_avistamientos,Responsable,Notas
+2019,30/Ago/2019,21,0,MA y MG,NA
+2019,01/Dic/2019,21,0,MA y MG,NA" ]
+}

--- a/tests/bats_tests/test_run_query.sh
+++ b/tests/bats_tests/test_run_query.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "run_query" {
-  run ./src/run_query tests/data/query_prueba.sql tests/data/test_2019-2020.csv
+  run src/run_query tests/data/query_prueba.sql tests/data/test_2019-2020.csv
   [ "$output" = "Temporada,Fecha,Cantidad_de_trampas_activas,Cantidad_de_avistamientos,Responsable,Notas
 2019,30/Ago/2019,21,0,MA y MG,NA
 2019,01/Dic/2019,21,0,MA y MG,NA" ]

--- a/tests/data/query_prueba.sql
+++ b/tests/data/query_prueba.sql
@@ -1,0 +1,5 @@
+SELECT 
+  SUBSTR(Fecha,8,4) as Temporada,
+  *
+FROM '${table_name}'
+WHERE CAST(SUBSTR(Fecha,8,4) AS INTEGER) > '2018'


### PR DESCRIPTION
Agregué el script `run_query` para que podamos tener por separado los queries en un archivo `.sql` y ejecutarlos con sqlite con `run_query`.
Pensaba agregar la cli a esta rama, pero creo que va mejor en una `release` 🤔